### PR TITLE
Fix mobile heading size for Success Stories section

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -2182,7 +2182,7 @@ export default function Index() {
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12 md:mb-16 animate-fade-in-up">
-            <h2 className="text-sm sm:text-2xl md:text-3xl lg:text-4xl xl:text-5xl font-black text-sunstone-navy mb-3 sm:mb-4 md:mb-6 px-3 sm:px-4">
+            <h2 className="text-base sm:text-xl md:text-2xl lg:text-3xl xl:text-4xl font-black text-sunstone-navy mb-3 sm:mb-4 md:mb-6 px-3 sm:px-4">
               Success Stories That Inspire
             </h2>
             <p className="text-xs sm:text-base md:text-lg lg:text-xl text-gray-700 max-w-4xl mx-auto font-medium px-3 sm:px-4">


### PR DESCRIPTION
## Purpose
Standardize the heading size for the "Success Stories That Inspire" section to match other headings across different screen sizes, particularly improving consistency in mobile view.

## Code changes
- Updated the h2 element's responsive text classes in the Success Stories section
- Changed mobile text size from `text-sm` to `text-base` for better consistency
- Adjusted responsive breakpoints: `sm:text-xl`, `md:text-2xl`, `lg:text-3xl`, `xl:text-4xl`
- Maintains the same styling and spacing while ensuring consistent heading hierarchy

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b66a2ab6e84e45d79b0eb0d1333d089e/echo-hub)

👀 [Preview Link](https://b66a2ab6e84e45d79b0eb0d1333d089e-echo-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b66a2ab6e84e45d79b0eb0d1333d089e</projectId>-->
<!--<branchName>echo-hub</branchName>-->